### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,18 +12,19 @@ branches:
 matrix:
     fast_finish: true
     include:
+        - php: 7.4
+        - php: 7.3
+        - php: 7.2
         - php: 7.1
         - php: 7.0
         - php: 5.6
         - php: 5.5
+          dist: trusty
         - php: 5.4
+          dist: trusty
         - php: 5.3
           dist: precise
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
-        - php: hhvm
-          sudo: required
-          dist: trusty
-          group: edge
 
 before_install:
     - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi;

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8",
+        "phpunit/phpunit": "^4.8.36",
         "scrutinizer/ocular": "^1.0",
-        "satooshi/php-coveralls": "^1.0"
+        "php-coveralls/php-coveralls": "^1.0"
     }
 }

--- a/tests/Base64UIDTest.php
+++ b/tests/Base64UIDTest.php
@@ -11,8 +11,9 @@
 namespace GpsLab\Component\Base64UID\Tests;
 
 use GpsLab\Component\Base64UID\Base64UID;
+use PHPUnit\Framework\TestCase;
 
-class Base64UIDTest extends \PHPUnit_Framework_TestCase
+class Base64UIDTest extends TestCase
 {
     public function testGenerateDefault()
     {


### PR DESCRIPTION
# Changed log
- Since the future `hhvm` version will be different from PHP versions and the `php-7.x` versions are released. It's time to remove the `hhvm` version.
- To be compatible with different PHP versions, using the `PHPUnit\Framework\TestCase` namespace.
- The `satooshi/php-coveralls` package is deprecated, and using the `php-coveralls/php-coveralls` package instead.