### PR TITLE
Verify generated id by RegExp

### DIFF
--- a/tests/Base64UIDTest.php
+++ b/tests/Base64UIDTest.php
@@ -18,32 +18,36 @@ class Base64UIDTest extends TestCase
     public function testGenerateDefault()
     {
         $id = Base64UID::generate();
-        $this->assertEquals(10, strlen($id));
+        $this->assertSame(10, strlen($id));
+        $this->assertRegExp('/^[-_a-zA-Z0-9]{10}$/', $id);
     }
 
     public function testGenerateCustomLength()
     {
         $id = Base64UID::generate(6);
-        $this->assertEquals(6, strlen($id));
+        $this->assertSame(6, strlen($id));
+        $this->assertRegExp('/^[-_a-zA-Z0-9]{6}$/', $id);
     }
 
     public function testGenerateIncorrectLength()
     {
         $id = Base64UID::generate(-3);
-        $this->assertEquals('', $id);
+        $this->assertEmpty($id);
     }
 
     public function testGenerateCustomCharset()
     {
         $charset = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ+/';
         $id = Base64UID::generate(11, $charset);
-        $this->assertEquals(11, strlen($id));
+        $this->assertSame(11, strlen($id));
+        $this->assertRegExp('/^[\/+a-zA-Z0-9]{11}$/', $id);
     }
 
     public function testGenerateCustomCharset2()
     {
         $charset = '0123456789abcdef';
         $id = Base64UID::generate(11, $charset);
-        $this->assertEquals(11, strlen($id));
+        $this->assertSame(11, strlen($id));
+        $this->assertRegExp('/^[a-f0-9]{11}$/', $id);
     }
 }


### PR DESCRIPTION
Use RegExp for validate generated id in tests.